### PR TITLE
Add timeout padding to setOutputOn

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -169,7 +169,7 @@ class Elk extends EventEmitter {
    * @param {number} seconds - Number of seconds output will be active
    */
   setOutputOn(outputId: number, seconds: number) {
-    let elk = new ElkMessage(`cn${leftPad(outputId.toString(), 3, '0')}${seconds.toString()}`, null);
+    let elk = new ElkMessage(`cn${leftPad(outputId.toString(), 3, '0')}${leftPad(seconds.toString(),5,'0')}`, null);
     this.connection.write(`${elk.message}\r\n`);
   }
 


### PR DESCRIPTION
Lack of padding on timeout for set output on command causes incorrect output on durations
Fix #7